### PR TITLE
Warnings as errors (please do not merge!!!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 Automata-*.tar
 
+# Dialyzer stuff
+.elixir_ls/

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ where you are running a specific context/it block containing line 31.
 #### Autonomy is the capacity of agent(s) to achieve a set of coordinated goals by their own means (without human intervention) adapting to environment variations.
 
 It combines five complementary  aspects:
-  - Perception e.g. interpretation of stimuli, removing ambiguity/vagueness from complex input data and determining relevant information based on context/strata/motif specific communications
-  - Reflection e.g. building/updating a faithful environment run-time model
-  - Goal management e.g. choosing among possible goals the most appropriate ones for a given configuration of the environment model
-  - Planning to achieve chosen goals
-  - Self-adaptation e.g. the ability to adjust behavior through learning and reasoning and to change dynamically the goal management and planning processes.
+  1. Perception e.g. interpretation of stimuli, removing ambiguity/vagueness from complex input data and determining relevant information based on context/strata/motif specific communications
+  2. Reflection e.g. building/updating a faithful environment run-time model
+  3. Goal management e.g. choosing among possible goals the most appropriate ones for a given configuration of the environment model
+  4. Planning to achieve chosen goals
+  5. Self-adaptation e.g. the ability to adjust behavior through learning and reasoning and to change dynamically the goal management and planning processes.
 
 
 Note that the five aspects are orthogonal. The first two aspects deal with
@@ -75,14 +75,10 @@ Note that the five aspects are orthogonal. The first two aspects deal with
 
  2. Autonomous Coordinability: Even if any subsystem fails, is repaired, and/or is newly added, the other subsystems can coordinate their individual objectives among themselves and can function in a coordinated fashion.
 
-    - With `Automata`, while it is a property of the behavior tree implementation that user-defined nodes are independent, it is left to the designer to ensure coordination independence among all nodes in order to satisfy this property.
-
 ## Features
 
 ### Functional Features:
 #### General
-
-- Meta-level control (triggered each heartbeat) to support agent interaction, network reorganization. Meta-level control is the ability of an agent to optimize its long term performance by choosing and sequencing its deliberation and execution actions appropriately. <sup>[2](#mmlcfootnote1)</sup>
 
 
 - #### User defined behavior trees
@@ -100,7 +96,9 @@ Note that the five aspects are orthogonal. The first two aspects deal with
 
   - A global blackboard that can coordinate automata without being a central point of failure.
   - Individual automaton blackboards readable by all automata, writeable by owning automaton
-  - Neuromorphic/Probabilistic computing, potentially bringing the code to the data rather than the other way around.
+
+- #### Meta Level Control
+  - Meta-level control (triggered each heartbeat) to support agent interaction, any potential network reorganization. Meta-level control is the ability of an agent to optimize its long term performance by choosing and sequencing its deliberation and execution actions appropriately. <sup>[2](#mmlcfootnote1)</sup>
 
 ### Performance Features:
 - Concurrency
@@ -111,13 +109,14 @@ Note that the five aspects are orthogonal. The first two aspects deal with
   - OTP Supervision Trees and the "fail fast" principle provide strong guarantees for error recovery and self healing systems.
 - Scalability & Distribution
   -  Elixir can handle millions of processes (134 million +/-) utilizing all cores without breaking a sweat on a single machine, and easily distributes work onto multiple machines with its builtin distribution mechanisms, and there is CRDT support with [Horde](https://github.com/derekkraan/horde).
-  - Behavior trees provide value stream scalability (design/development and operations/testing).
+  - Behavior trees provide value chain efficiency/scalability (in both design/development and operations/testing) compared to previous state of the art AI control techniques.
 - Modularity
   - Modular BT's allow the designer to hierarchically combine independently developed, tested, deployed, and reusable unit behaviors that provide more valuable emergent properties in the large.
 - Flexibility
   - A design goal of `Automata` is to allow high flexibility via extreme abstraction (to enable design space evolution, support diversity in applications)
 - Simplicity of Implementation
-  - Elixir's meta-programming facilities enable very user-friendly API's so developers don't need to know the details of BT's or Automata Theory to get things done, and BT's themselves lend efficiency via simplicity to the development value chain.
+  - Elixir's meta-programming facilities enable very user-friendly API's so developers don't need to know the details of BT's or Automata Theory to get things done, and BT's themselves lend efficiency to the development value chain.
+- Neuromorphic/Probabilistic computing, potentially bringing the code to the data rather than the other way around.
 
 ### Applications
 - Trading Systems

--- a/lib/automata/core/automaton/composites/sequence.ex
+++ b/lib/automata/core/automaton/composites/sequence.ex
@@ -19,6 +19,8 @@ defmodule Automaton.Composite.Sequence do
       def update(%{workers: workers} = state) do
         {w, status} = tick_workers(workers)
 
+        # TODO: what to do when num seq actions is large enough
+        # that previous workers
         case status do
           :bh_failure ->
             Enum.each(state.workers, fn w ->
@@ -27,6 +29,7 @@ defmodule Automaton.Composite.Sequence do
               ])
 
               # status = GenServer.stop(w, :normal, :infinity)
+              # IO.inspect(status)
               # Process.exit(w, :normal)
             end)
 
@@ -51,15 +54,9 @@ defmodule Automaton.Composite.Sequence do
           cond do
             # If the child fails, or keeps running, do the same.
             status == :bh_running ->
-              # IO.puts("CONT")
-              # IO.inspect([Process.info(w)[:registered_name], status])
-              # IO.inspect([Process.info(self)[:registered_name], status])
               {:cont, {w, :bh_running}}
 
             status != :bh_success ->
-              # IO.puts("HALT")
-              # IO.inspect([Process.info(w)[:registered_name], status])
-              # IO.inspect([Process.info(self)[:registered_name], status])
               {:halt, {w, status}}
           end
         end)
@@ -88,15 +85,6 @@ defmodule Automaton.Composite.Sequence do
             IO.inspect("SEQUENCE TERMINATED - FAILED",
               label: Process.info(self)[:registered_name]
             )
-
-          # Enum.each(state.workers, fn w ->
-          #   IO.inspect([
-          #     "#{Process.info(w)[:registered_name]} stop"
-          #   ])
-          #
-          #   # status = GenServer.stop(w, :normal, :infinity)
-          #   Process.exit(w, :normal)
-          # end)
 
           :bh_success ->
             IO.inspect(["SEQUENCE TERMINATED - SUCCEEDED"],

--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,7 @@ defmodule Automata.MixProject do
     [
       app: :automata,
       version: "0.1.0",
+      elixirc_options: [warnings_as_errors: true],
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/spec/automata_test.exs
+++ b/spec/automata_test.exs
@@ -7,9 +7,7 @@ defmodule AutomataTest do
   setup_all do
     # TODO: Load user-configs into node_configs
     nodes_config = [
-      [name: "MockSeq1", mfa: {MockSeq1, :start_link, []}],
-      [name: "MockSeq2", mfa: {MockSeq2, :start_link, []}],
-      [name: "MockSeq3", mfa: {MockSeq3, :start_link, []}]
+      [name: "MockSeq1", mfa: {MockSeq1, :start_link, []}]
     ]
 
     [nodes_config: nodes_config]


### PR DESCRIPTION
This branch aim is to made warnings more visible.

If you checkout from it and then `mix compile` - you'll see them all :)

At the moment there are quite a lot of warnings, mostly coming from macros.
I'm not macros master but think it still can and should be fixed.

Want your opinion first on that @upstarter since it might require some effort. 